### PR TITLE
qdrant/qdrant#2315 review suggestions

### DIFF
--- a/docs/grpc/docs.md
+++ b/docs/grpc/docs.md
@@ -85,6 +85,7 @@
     - [FieldCondition](#qdrant-FieldCondition)
     - [Filter](#qdrant-Filter)
     - [GeoBoundingBox](#qdrant-GeoBoundingBox)
+    - [GeoLineString](#qdrant-GeoLineString)
     - [GeoPoint](#qdrant-GeoPoint)
     - [GeoPolygon](#qdrant-GeoPolygon)
     - [GeoRadius](#qdrant-GeoRadius)
@@ -1489,6 +1490,21 @@ The JSON representation for `Value` is a JSON value.
 
 
 
+<a name="qdrant-GeoLineString"></a>
+
+### GeoLineString
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| points | [GeoPoint](#qdrant-GeoPoint) | repeated | Ordered sequence of GeoPoints representing the line |
+
+
+
+
+
+
 <a name="qdrant-GeoPoint"></a>
 
 ### GeoPoint
@@ -1513,7 +1529,7 @@ The JSON representation for `Value` is a JSON value.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| points | [GeoPoint](#qdrant-GeoPoint) | repeated | Ordered list of coordinates representing the vertices of a polygon. The minimum size is 4, and the first coordinate and the last coordinate should be the same to form a closed polygon. |
+| rings | [GeoLineString](#qdrant-GeoLineString) | repeated | An ordered list of lists of GeoPoint coordinates, arranged in order. For Polygons with more than one of these rings, the first MUST be the exterior ring, and any others MUST be interior rings. The exterior ring bounds the surface, and the interior rings (if present) bound holes within the surface. |
 
 
 

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -5204,14 +5204,29 @@
         }
       },
       "GeoPolygon": {
-        "description": "Geo filter request\n\nMatches coordinates inside the polygon, defined by the given coordinates in order.",
+        "description": "Geo filter request\n\nMatches coordinates inside the polygon, defined by exterior and interiors.",
+        "type": "object",
+        "required": [
+          "rings"
+        ],
+        "properties": {
+          "rings": {
+            "description": "An ordered list of lists of GeoPoint coordinates, arranged in order. For Polygons with more than one of these rings, the first MUST be the exterior ring, and any others MUST be interior rings. The exterior ring bounds the surface, and the interior rings (if present) bound holes within the surface.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeoLineString"
+            }
+          }
+        }
+      },
+      "GeoLineString": {
+        "description": "Ordered sequence of GeoPoints representing the line",
         "type": "object",
         "required": [
           "points"
         ],
         "properties": {
           "points": {
-            "description": "Ordered list of coordinates representing the vertices of a polygon.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/GeoPoint"

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -166,9 +166,10 @@ fn configure_validation(builder: Builder) -> Builder {
             ("RecommendPointGroups.limit", "range(min = 1)"),
             ("RecommendPointGroups.params", ""),
             ("CountPoints.collection_name", "length(min = 1, max = 255)"),
-            ("GeoPolygon.points", "custom = \"crate::grpc::validate::validate_geo_polygon\""),
+            ("GeoPolygon.rings", "custom = \"crate::grpc::validate::validate_geo_polygon\""),
         ], &[])
         .type_attribute("GeoPoint", "#[derive(serde::Serialize)]")
+        .type_attribute("GeoLineString", "#[derive(serde::Serialize)]")
         // Service: points_internal_service.proto
         .validates(&[
             ("UpsertPointsInternal.upsert_points", ""),

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -8,7 +8,7 @@ use segment::types::{default_quantization_ignore_value, default_quantization_res
 use tonic::Status;
 use uuid::Uuid;
 
-use super::qdrant::{CompressionRatio, GroupId};
+use super::qdrant::{CompressionRatio, GeoLineString, GroupId};
 use crate::grpc::models::{CollectionsResponse, VersionInfo};
 use crate::grpc::qdrant::condition::ConditionOneOf;
 use crate::grpc::qdrant::payload_index_params::IndexParams;
@@ -904,21 +904,20 @@ impl TryFrom<GeoPolygon> for segment::types::GeoPolygon {
     type Error = Status;
 
     fn try_from(value: GeoPolygon) -> Result<Self, Self::Error> {
-        if value.points.is_empty() {
+        if value.rings.is_empty() {
             return Err(Status::invalid_argument("Empty GeoPolygon"));
         }
 
-        let points: Vec<segment::types::GeoPoint> =
-            value.points.into_iter().map(Into::into).collect();
-
-        Ok(Self { points })
+        Ok(Self {
+            rings: value.rings.into_iter().map(Into::into).collect(),
+        })
     }
 }
 
 impl From<segment::types::GeoPolygon> for GeoPolygon {
     fn from(value: segment::types::GeoPolygon) -> Self {
         Self {
-            points: value.points.into_iter().map(Into::into).collect(),
+            rings: value.rings.into_iter().map(Into::into).collect(),
         }
     }
 }
@@ -928,6 +927,22 @@ impl From<GeoPoint> for segment::types::GeoPoint {
         Self {
             lon: value.lon,
             lat: value.lat,
+        }
+    }
+}
+
+impl From<GeoLineString> for segment::types::GeoLineString {
+    fn from(value: GeoLineString) -> Self {
+        Self {
+            points: value.points.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<segment::types::GeoLineString> for GeoLineString {
+    fn from(value: segment::types::GeoLineString) -> Self {
+        Self {
+            points: value.points.into_iter().map(Into::into).collect(),
         }
     }
 }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -524,11 +524,17 @@ message GeoRadius {
   float radius = 2; // In meters
 }
 
+message GeoLineString {
+  repeated GeoPoint points = 1;  // Ordered sequence of GeoPoints representing the line
+}
+
 message GeoPolygon {
-  // Ordered list of coordinates representing the vertices of a polygon.
-  // The minimum size is 4, and the first coordinate and the last coordinate
-  // should be the same to form a closed polygon.
-  repeated GeoPoint points = 1;
+    // An ordered list of lists of GeoPoint coordinates, arranged in order.
+    // For Polygons with more than one of these rings, the first MUST be
+    // the exterior ring, and any others MUST be interior rings. The exterior
+    // ring bounds the surface, and the interior rings (if present) bound holes
+    // within the surface.
+  repeated GeoLineString rings = 1;
 }
 
 message ValuesCount {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -3484,16 +3484,26 @@ pub struct GeoRadius {
     #[prost(float, tag = "2")]
     pub radius: f32,
 }
+#[derive(serde::Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GeoLineString {
+    /// Ordered sequence of GeoPoints representing the line
+    #[prost(message, repeated, tag = "1")]
+    pub points: ::prost::alloc::vec::Vec<GeoPoint>,
+}
 #[derive(validator::Validate)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GeoPolygon {
-    /// Ordered list of coordinates representing the vertices of a polygon.
-    /// The minimum size is 4, and the first coordinate and the last coordinate
-    /// should be the same to form a closed polygon.
+    /// An ordered list of lists of GeoPoint coordinates, arranged in order.
+    /// For Polygons with more than one of these rings, the first MUST be
+    /// the exterior ring, and any others MUST be interior rings. The exterior
+    /// ring bounds the surface, and the interior rings (if present) bound holes
+    /// within the surface.
     #[prost(message, repeated, tag = "1")]
     #[validate(custom = "crate::grpc::validate::validate_geo_polygon")]
-    pub points: ::prost::alloc::vec::Vec<GeoPoint>,
+    pub rings: ::prost::alloc::vec::Vec<GeoLineString>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/lib/segment/src/index/field_index/geo_hash.rs
+++ b/lib/segment/src/index/field_index/geo_hash.rs
@@ -874,7 +874,7 @@ mod tests {
             lat: 40.76517460,
             lon: -74.00101399,
         };
-        assert!(geo_box.check_point(center.lon, center.lat));
+        assert!(geo_box.check_point(center));
     }
 
     #[test]

--- a/lib/segment/src/index/field_index/geo_hash.rs
+++ b/lib/segment/src/index/field_index/geo_hash.rs
@@ -19,8 +19,8 @@ const COORD_EPS: f64 = 1e-12;
 impl From<GeoPoint> for Coord<f64> {
     fn from(point: GeoPoint) -> Self {
         Self {
-            x: point.lat,
-            y: point.lon,
+            x: point.lon,
+            y: point.lat,
         }
     }
 }

--- a/lib/segment/src/index/field_index/geo_index.rs
+++ b/lib/segment/src/index/field_index/geo_index.rs
@@ -260,13 +260,13 @@ impl GeoMapIndex {
 
     pub fn check_radius(&self, idx: PointOffsetType, radius: &GeoRadius) -> bool {
         self.get_values(idx)
-            .map(|values| values.iter().any(|x| radius.check_point(x.lon, x.lat)))
+            .map(|values| values.iter().any(|x| radius.check_point(*x)))
             .unwrap_or(false)
     }
 
     pub fn check_box(&self, idx: PointOffsetType, bbox: &GeoBoundingBox) -> bool {
         self.get_values(idx)
-            .map(|values| values.iter().any(|x| bbox.check_point(x.lon, x.lat)))
+            .map(|values| values.iter().any(|x| bbox.check_point(*x)))
             .unwrap_or(false)
     }
 
@@ -532,7 +532,7 @@ impl PayloadFieldIndex for GeoMapIndex {
                         .get(*point as usize)
                         .unwrap()
                         .iter()
-                        .any(|point| geo_condition_copy.check_point(point.lon, point.lat))
+                        .any(|point| geo_condition_copy.check_point(*point))
                 },
             )));
         }
@@ -546,7 +546,7 @@ impl PayloadFieldIndex for GeoMapIndex {
                         .get(*point as usize)
                         .unwrap()
                         .iter()
-                        .any(|point| geo_condition_copy.check_point(point.lon, point.lat))
+                        .any(|point| geo_condition_copy.check_point(*point))
                 },
             )));
         }
@@ -560,7 +560,7 @@ impl PayloadFieldIndex for GeoMapIndex {
                         .get(*point as usize)
                         .unwrap()
                         .iter()
-                        .any(|point| geo_condition_copy.check_point(point.lon, point.lat))
+                        .any(|point| geo_condition_copy.check_point(*point))
                 },
             )));
         }
@@ -715,7 +715,7 @@ mod tests {
             .filter(|(_idx, geo_points)| {
                 geo_points
                     .iter()
-                    .any(|geo_point| geo_radius.check_point(geo_point.lon, geo_point.lat))
+                    .any(|geo_point| geo_radius.check_point(*geo_point))
             })
             .map(|(idx, _geo_points)| idx as PointOffsetType)
             .collect_vec();

--- a/lib/segment/src/index/query_optimization/condition_converter.rs
+++ b/lib/segment/src/index/query_optimization/condition_converter.rs
@@ -179,7 +179,7 @@ pub fn get_geo_polygon_checkers(
             geo_index.get_values(point_id).map_or(false, |values| {
                 values
                     .iter()
-                    .any(|geo_point| geo_polygon.check_point(geo_point.lon, geo_point.lat))
+                    .any(|geo_point| geo_polygon.check_point(*geo_point))
             })
         })),
         _ => None,
@@ -195,7 +195,7 @@ pub fn get_geo_radius_checkers(
             geo_index.get_values(point_id).map_or(false, |values| {
                 values
                     .iter()
-                    .any(|geo_point| geo_radius.check_point(geo_point.lon, geo_point.lat))
+                    .any(|geo_point| geo_radius.check_point(*geo_point))
             })
         })),
         _ => None,
@@ -212,7 +212,7 @@ pub fn get_geo_bounding_box_checkers(
                 None => false,
                 Some(values) => values
                     .iter()
-                    .any(|geo_point| geo_bounding_box.check_point(geo_point.lon, geo_point.lat)),
+                    .any(|geo_point| geo_bounding_box.check_point(*geo_point)),
             }
         })),
         _ => None,

--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -3,7 +3,7 @@
 use serde_json::Value;
 
 use crate::types::{
-    AnyVariants, FieldCondition, GeoBoundingBox, GeoPolygon, GeoRadius, Match, MatchAny,
+    AnyVariants, FieldCondition, GeoBoundingBox, GeoPoint, GeoPolygon, GeoRadius, Match, MatchAny,
     MatchExcept, MatchText, MatchValue, Range, ValueVariants, ValuesCount,
 };
 
@@ -123,52 +123,19 @@ impl ValueChecker for Range {
 
 impl ValueChecker for GeoBoundingBox {
     fn check_match(&self, payload: &Value) -> bool {
-        match payload {
-            Value::Object(obj) => {
-                let lon_op = obj.get("lon").and_then(|x| x.as_f64());
-                let lat_op = obj.get("lat").and_then(|x| x.as_f64());
-
-                if let (Some(lon), Some(lat)) = (lon_op, lat_op) {
-                    return self.check_point(lon, lat);
-                }
-                false
-            }
-            _ => false,
-        }
+        GeoPoint::from_value(payload).map_or(false, |point| self.check_point(point))
     }
 }
 
 impl ValueChecker for GeoRadius {
     fn check_match(&self, payload: &Value) -> bool {
-        match payload {
-            Value::Object(obj) => {
-                let lon_op = obj.get("lon").and_then(|x| x.as_f64());
-                let lat_op = obj.get("lat").and_then(|x| x.as_f64());
-
-                if let (Some(lon), Some(lat)) = (lon_op, lat_op) {
-                    return self.check_point(lon, lat);
-                }
-                false
-            }
-            _ => false,
-        }
+        GeoPoint::from_value(payload).map_or(false, |point| self.check_point(point))
     }
 }
 
 impl ValueChecker for GeoPolygon {
     fn check_match(&self, payload: &Value) -> bool {
-        match payload {
-            Value::Object(obj) => {
-                let lon_op = obj.get("lon").and_then(|x| x.as_f64());
-                let lat_op = obj.get("lat").and_then(|x| x.as_f64());
-
-                if let (Some(lon), Some(lat)) = (lon_op, lat_op) {
-                    return self.check_point(lon, lat);
-                }
-                false
-            }
-            _ => false,
-        }
+        GeoPoint::from_value(payload).map_or(false, |point| self.check_point(point))
     }
 }
 

--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -3,8 +3,8 @@
 use serde_json::Value;
 
 use crate::types::{
-    AnyVariants, FieldCondition, GeoBoundingBox, GeoRadius, Match, MatchAny, MatchExcept,
-    MatchText, MatchValue, Range, ValueVariants, ValuesCount,
+    AnyVariants, FieldCondition, GeoBoundingBox, GeoPolygon, GeoRadius, Match, MatchAny,
+    MatchExcept, MatchText, MatchValue, Range, ValueVariants, ValuesCount,
 };
 
 pub trait ValueChecker {
@@ -45,6 +45,11 @@ impl ValueChecker for FieldCondition {
         res = res
             || self
                 .geo_bounding_box
+                .as_ref()
+                .map_or(false, |condition| condition.check_match(payload));
+        res = res
+            || self
+                .geo_polygon
                 .as_ref()
                 .map_or(false, |condition| condition.check_match(payload));
         res = res
@@ -134,6 +139,23 @@ impl ValueChecker for GeoBoundingBox {
 }
 
 impl ValueChecker for GeoRadius {
+    fn check_match(&self, payload: &Value) -> bool {
+        match payload {
+            Value::Object(obj) => {
+                let lon_op = obj.get("lon").and_then(|x| x.as_f64());
+                let lat_op = obj.get("lat").and_then(|x| x.as_f64());
+
+                if let (Some(lon), Some(lat)) = (lon_op, lat_op) {
+                    return self.check_point(lon, lat);
+                }
+                false
+            }
+            _ => false,
+        }
+    }
+}
+
+impl ValueChecker for GeoPolygon {
     fn check_match(&self, payload: &Value) -> bool {
         match payload {
             Value::Object(obj) => {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -644,10 +644,7 @@ pub struct GeoPoint {
 
 impl From<GeoPoint> for Point<f64> {
     fn from(point: GeoPoint) -> Self {
-        Self(Coord {
-            x: point.lon,
-            y: point.lat,
-        })
+        Self(point.into())
     }
 }
 
@@ -1245,7 +1242,7 @@ pub struct GeoRadius {
 impl GeoRadius {
     pub fn check_point(&self, point: GeoPoint) -> bool {
         let query_center = Point::new(self.center.lon, self.center.lat);
-        query_center.haversine_distance(&Point::from(point)) < self.radius
+        query_center.haversine_distance(&point.into()) < self.radius
     }
 }
 

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -655,7 +655,7 @@ fn test_struct_payload_geo_polygon_index() {
                 })
                 .collect(),
         };
-        line.points.push(line.points[0].clone()); // add last point that is identical to the first
+        line.points.push(line.points[0]); // add last point that is identical to the first
         line
     }
 

--- a/openapi/tests/openapi_integration/helpers/collection_setup.py
+++ b/openapi/tests/openapi_integration/helpers/collection_setup.py
@@ -11,6 +11,112 @@ def drop_collection(collection_name='test_collection'):
     )
     assert response.ok
 
+def geo_collection_setup(
+        collection_name='test_collection',
+        on_disk_payload=False,
+        on_disk_vectors=None,
+):
+    on_disk_vectors = on_disk_vectors or bool(int(os.getenv('QDRANT__ON_DISK_VECTORS', 0)))
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="DELETE",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "size": 4,
+                "distance": "Dot",
+                "on_disk": on_disk_vectors
+            },
+            "on_disk_payload": on_disk_payload
+        }
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="GET",
+        path_params={'collection_name': collection_name},
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": [0.05, 0.61, 0.76, 0.74],
+                    "payload": {
+                        "value": 1,
+                        "location": {
+                                    "lon": 50.5200,
+                                    "lat": 50.4050
+                                }}
+                },
+                {
+                    "id": 2,
+                    "vector": [0.19, 0.81, 0.75, 0.11],
+                    "payload": {
+                        "value": 2,
+                        "location": {
+                                    "lon": 60.5200,
+                                    "lat": 60.4050
+                                }}
+                },
+                {
+                    "id": 3,
+                    "vector": [0.36, 0.55, 0.47, 0.94],
+                    "payload": {
+                        "value": 3,
+                        "location": {
+                                    "lon": -60.5200,
+                                    "lat": -60.4050
+                                }}
+                },
+                {
+                    "id": 4,
+                    "vector": [0.18, 0.01, 0.85, 0.80],
+                    "payload": {
+                        "value": 4,
+                        "location": {
+                                    "lon": 80.5200,
+                                    "lat": 80.4050
+                                }
+                                }
+                },
+                {
+                    "id": 5,
+                    "vector": [0.24, 0.18, 0.22, 0.44],
+                    "payload": {
+                        "value": 5,
+                        "location": {
+                                    "lon": -72.5200,
+                                    "lat": -72.4050
+                                }}
+                },
+                # add a entry doesn't contain location
+                {
+                    "id": 6,
+                    "vector": [0.24, 0.18, 0.22, 0.44],
+                    "payload": {
+                        "value": 6}
+                },
+            ]
+        }
+    )
+    assert response.ok
+
 
 def basic_collection_setup(
         collection_name='test_collection',

--- a/openapi/tests/openapi_integration/test_geo_filter.py
+++ b/openapi/tests/openapi_integration/test_geo_filter.py
@@ -1,0 +1,134 @@
+import random
+
+import pytest
+
+from .helpers.helpers import request_with_validation
+from .helpers.collection_setup import geo_collection_setup, drop_collection
+
+collection_name = "test_collection_filter"
+
+
+@pytest.fixture(autouse=True, scope="module")
+def setup():
+    geo_collection_setup(collection_name=collection_name)
+    yield
+    drop_collection(collection_name=collection_name)
+
+
+def test_geo_polygon():
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/search",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "vector": [0.2, 0.1, 0.9, 0.7],
+            "limit": 3,
+            "filter": {
+                "must": [
+                    {
+                        "key": "location",
+                        "geo_polygon": {
+                            "rings": [
+                                {
+                                    "points": [
+                                        {"lon": 55.455868, "lat": 55.495862},
+                                        {"lon": 86.455868, "lat": 55.495862},
+                                        {"lon": 86.455868, "lat": 86.495862},
+                                        {"lon": 55.455868, "lat": 86.495862},
+                                        {"lon": 55.455868, "lat": 55.495862},
+                                    ]
+                                }
+                            ]
+                        },
+                    }
+                ]
+            },
+        },
+    )
+    assert response.ok
+
+    json = response.json()
+    assert len(json["result"]) == 2
+
+    ids = [x["id"] for x in json["result"]]
+    assert 2 in ids
+    assert 4 in ids
+
+    # a polygon spans from negative to positive
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/search",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "vector": [0.2, 0.1, 0.9, 0.7],
+            "limit": 3,
+            "filter": {
+                "must": [
+                    {
+                        "key": "location",
+                        "geo_polygon": {
+                            "rings": [
+                                {
+                                    "points": [
+                                        {"lon": -70.0, "lat": -70.0},
+                                        {"lon": 60.0, "lat": -70.0},
+                                        {"lon": 60.0, "lat": 60.0},
+                                        {"lon": -70.0, "lat": 60.0},
+                                        {"lon": -70.0, "lat": -70.0},
+                                    ]
+                                }
+                            ]
+                        },
+                    }
+                ]
+            },
+        },
+    )
+    assert response.ok
+
+    json = response.json()
+    assert len(json["result"]) == 2
+
+    ids = [x["id"] for x in json["result"]]
+    assert 1 in ids
+    assert 3 in ids
+
+    # a polygon cover all geo space lat[-90, -90], lon[-180, 180]
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/search",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "vector": [0.2, 0.1, 0.9, 0.7],
+            "limit": 3,
+            "filter": {
+                "must": [
+                    {
+                        "key": "location",
+                        "geo_polygon": {
+                            "rings": [
+                                {
+                                    "points": [
+                                        {"lon": -180.0, "lat": -90.0},
+                                        {"lon": 180.0, "lat": -90.0},
+                                        {"lon": 180.0, "lat": 90.0},
+                                        {"lon": -180.0, "lat": 90.0},
+                                        {"lon": -180.0, "lat": -90.0},
+                                    ]
+                                }
+                            ]
+                        },
+                    }
+                ]
+            },
+        },
+    )
+    assert response.ok
+
+    json = response.json()
+    assert len(json["result"]) == 3
+
+    ids = [x["id"] for x in json["result"]]
+    assert 1 in ids
+    assert 3 in ids
+    assert 4 in ids


### PR DESCRIPTION
Suggestions for qdrant/qdrant#2315.

Basically changes `check_point()` to take a `GeoPoint` instead of `lon` and `lat`, which makes more refactoring possible, and gets rid of code triplication